### PR TITLE
chore: improve hash update script robustness

### DIFF
--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,3 +1,3 @@
 {
-  "nodeModules": "sha256-6ZI7yAdQlt1guvxOaT/7TSuaL0UD9SbIX3jrM6K4Hdo="
+  "nodeModules": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 }

--- a/nix/scripts/update-hashes.sh
+++ b/nix/scripts/update-hashes.sh
@@ -3,11 +3,9 @@
 set -euo pipefail
 
 DUMMY="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-HASH_FILE="$REPO_ROOT/nix/hashes.json"
-
-cd "$REPO_ROOT"
+SYSTEM=${SYSTEM:-x86_64-linux}
+DEFAULT_HASH_FILE=${MODULES_HASH_FILE:-nix/hashes.json}
+HASH_FILE=${HASH_FILE:-$DEFAULT_HASH_FILE}
 
 if [ ! -f "$HASH_FILE" ]; then
   cat >"$HASH_FILE" <<EOF
@@ -17,13 +15,23 @@ if [ ! -f "$HASH_FILE" ]; then
 EOF
 fi
 
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if ! git ls-files --error-unmatch "$HASH_FILE" >/dev/null 2>&1; then
+    git add -N "$HASH_FILE" >/dev/null 2>&1 || true
+  fi
+fi
+
+export DUMMY
+export NIX_KEEP_OUTPUTS=1
+export NIX_KEEP_DERIVATIONS=1
+
 cleanup() {
-  rm -f "${BUILD_LOG:-}"
+  rm -f "${JSON_OUTPUT:-}" "${BUILD_LOG:-}" "${TMP_EXPR:-}"
 }
 
 trap cleanup EXIT
 
-write_hash() {
+write_node_modules_hash() {
   local value="$1"
   local temp
   temp=$(mktemp)
@@ -31,31 +39,74 @@ write_hash() {
   mv "$temp" "$HASH_FILE"
 }
 
-echo "Setting dummy hash..."
-write_hash "$DUMMY"
-
-BUILD_LOG=$(mktemp)
-
-echo "Building to discover correct hash..."
+TARGET="packages.${SYSTEM}.default"
+MODULES_ATTR=".#packages.${SYSTEM}.default.node_modules"
 CORRECT_HASH=""
 
-if nix build 2>"$BUILD_LOG"; then
-  # Build succeeded - hash the output
-  CORRECT_HASH=$(nix eval --raw '.#packages.'$(nix eval --impure --expr 'builtins.currentSystem')'.default.node_modules.outPath' 2>/dev/null | xargs nix hash path --sri 2>/dev/null || true)
+DRV_PATH="$(nix eval --raw "${MODULES_ATTR}.drvPath")"
+
+echo "Setting dummy node_modules outputHash for ${SYSTEM}..."
+write_node_modules_hash "$DUMMY"
+
+BUILD_LOG=$(mktemp)
+JSON_OUTPUT=$(mktemp)
+
+echo "Building node_modules for ${SYSTEM} to discover correct outputHash..."
+echo "Attempting to realize derivation: ${DRV_PATH}"
+REALISE_OUT=$(nix-store --realise "$DRV_PATH" --keep-failed 2>&1 | tee "$BUILD_LOG" || true)
+
+BUILD_PATH=$(echo "$REALISE_OUT" | grep "^/nix/store/" | head -n1 || true)
+if [ -n "$BUILD_PATH" ] && [ -d "$BUILD_PATH" ]; then
+  echo "Realized node_modules output: $BUILD_PATH"
+  CORRECT_HASH=$(nix hash path --sri "$BUILD_PATH" 2>/dev/null || true)
 fi
 
 if [ -z "$CORRECT_HASH" ]; then
-  # Extract from error message
   CORRECT_HASH="$(grep -E 'got:\s+sha256-[A-Za-z0-9+/=]+' "$BUILD_LOG" | awk '{print $2}' | head -n1 || true)"
+
+  if [ -z "$CORRECT_HASH" ]; then
+    CORRECT_HASH="$(grep -A2 'hash mismatch' "$BUILD_LOG" | grep 'got:' | awk '{print $2}' | sed 's/sha256:/sha256-/' || true)"
+  fi
+
+  if [ -z "$CORRECT_HASH" ]; then
+    echo "Searching for kept failed build directory..."
+    KEPT_DIR=$(grep -oE "build directory.*'[^']+'" "$BUILD_LOG" | grep -oE "'/[^']+'" | tr -d "'" | head -n1)
+
+    if [ -z "$KEPT_DIR" ]; then
+      KEPT_DIR=$(grep -oE '/nix/var/nix/builds/[^ ]+' "$BUILD_LOG" | head -n1)
+    fi
+
+    if [ -n "$KEPT_DIR" ] && [ -d "$KEPT_DIR" ]; then
+      echo "Found kept build directory: $KEPT_DIR"
+      if [ -d "$KEPT_DIR/build" ]; then
+        HASH_PATH="$KEPT_DIR/build"
+      else
+        HASH_PATH="$KEPT_DIR"
+      fi
+
+      echo "Attempting to hash: $HASH_PATH"
+      ls -la "$HASH_PATH" || true
+
+      if [ -d "$HASH_PATH/node_modules" ]; then
+        CORRECT_HASH=$(nix hash path --sri "$HASH_PATH" 2>/dev/null || true)
+        echo "Computed hash from kept build: $CORRECT_HASH"
+      fi
+    fi
+  fi
 fi
 
 if [ -z "$CORRECT_HASH" ]; then
-  echo "Failed to determine correct hash."
+  echo "Failed to determine correct node_modules hash for ${SYSTEM}."
   echo "Build log:"
   cat "$BUILD_LOG"
   exit 1
 fi
 
-write_hash "$CORRECT_HASH"
+write_node_modules_hash "$CORRECT_HASH"
 
-echo "Hash updated: $CORRECT_HASH"
+jq -e --arg hash "$CORRECT_HASH" '.nodeModules == $hash' "$HASH_FILE" >/dev/null
+
+echo "node_modules hash updated for ${SYSTEM}: $CORRECT_HASH"
+
+rm -f "$BUILD_LOG"
+unset BUILD_LOGcho "Hash updated: $CORRECT_HASH"


### PR DESCRIPTION
Refactor update-hashes.sh to support configurable system targets and improve hash discovery. Make the script more resilient by supporting environment variable overrides for system type and hash file location, add git tracking checks, and enhance hash extraction from build failures with multiple fallback strategies. Also update dummy hash in hashes.json to reflect test value.
